### PR TITLE
Update repository references for the new location

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -12,10 +12,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Clone mtreinish/qiskit-neko PUBLIC repository
+    - name: Clone Qiskit/qiskit-neko PUBLIC repository
       uses: actions/checkout@v3
       with:
-        repository: mtreinish/qiskit-neko
+        repository: Qiskit/qiskit-neko
         path: qiskit-neko
     - name: Access cloned repository content
       run: |
@@ -25,7 +25,7 @@ runs:
         pip install .
         cd ..
     - name: Checkout base repository
-      uses: actions/checkout@v3   
+      uses: actions/checkout@v3
     - name: Install repo under test
       run: |
         ${{ inputs.repo_install_command }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ When writing tests for Qiskit Neko there are some guidelines to keep in mind.
 
 All test classes in qiskit-neko should be inherited from the base test class:
 `BaseTestCase` (defined in:
-https://github.com/mtreinish/qiskit-neko/blob/main/qiskit_neko/tests/base.py).
+https://github.com/Qiskit/qiskit-neko/blob/main/qiskit_neko/tests/base.py).
 This base test class provides common setup functionality that automate most
 of the necessary fixtures like setting per test timeouts and capturing stdout,
 stderr, logging, etc.  But, for the purposes of using backends the base test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qiskit-neko
 
-[![License](https://img.shields.io/github/license/mtreinish/qiskit-neko.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/github/license/Qiskit/qiskit-neko.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
 
 This repository contains integration tests for Qiskit. These tests are used
 for primarily for two purposes as backwards compatibility testing for Qiskit
@@ -15,12 +15,12 @@ objects that provide an interface to Quantum hardware or a simulator.
 Currently qiskit-neko is not designed to run as a standalone package and you
 need to checkout the git source repository to run it. This is done to simplify
 the execution of the tests as qiskit-neko leverages the
-[``stestr``](https://github.com/mtreinish/stestr) for the execution of its
+[``stestr``](https://github.com/Qiskit/stestr) for the execution of its
 tests. To install qiskit-neko you need to first clone it with
 [git](https://git-scm.com/):
 
 ```
-git clone https://github.com/mtreinish/qiskit-neko.git
+git clone https://github.com/Qiskit/qiskit-neko.git
 ```
 
 then you can install it using pip into your python environment

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qiskit-neko",
   "version": "1.0.0",
-  "description": "[![License](https://img.shields.io/github/license/mtreinish/qiskit-neko.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)",
+  "description": "[![License](https://img.shields.io/github/license/Qiskit/qiskit-neko.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)",
   "main": "index.js",
   "directories": {
     "doc": "docs",
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mtreinish/qiskit-neko.git"
+    "url": "git+https://github.com/Qiskit/qiskit-neko.git"
   },
   "keywords": [],
   "author": "",
   "license": "apache 2.0",
   "bugs": {
-    "url": "https://github.com/mtreinish/qiskit-neko/issues"
+    "url": "https://github.com/Qiskit/qiskit-neko/issues"
   },
-  "homepage": "https://github.com/mtreinish/qiskit-neko#readme"
+  "homepage": "https://github.com/Qiskit/qiskit-neko#readme"
 }

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     description="Integration testing for Qiskit",
     long_description=README,
     long_description_content_type="text/markdown",
-    url="https://github.com/mtreinish/qiskit-neko",
+    url="https://github.com/Qiskit/qiskit-neko",
     author="Matthew Treinish",
     author_email="mtreinish@kortar.org",
     license="Apache 2.0",
@@ -61,9 +61,9 @@ setup(
     include_package_data=True,
     python_requires=">=3.7",
     project_urls={
-        "Bug Tracker": "https://github.com/mtreinish/qiskit-neko/issues",
+        "Bug Tracker": "https://github.com/Qiskit/qiskit-neko/issues",
         "Documentation": "https://qiskit.org/documentation/",
-        "Source Code": "https://github.com/mtreinish/qiskit-neko",
+        "Source Code": "https://github.com/Qiskit/qiskit-neko",
     },
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
The qiskit-neko project will be part of qiskit soon, in preparation for
the migration this PR changes all references to mtreinish/qiskit-neko to
Qiskit/qiskit-neko.