### PR TITLE
Add missing required shell arguments from custom action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,9 +23,13 @@ runs:
       shell: bash
     - name: Checkout base repository
       uses: actions/checkout@v3
+      with:
+        path: repo_under_test
     - name: Install repo under test
       run: |
+        pushd repo_under_test
         ${{ inputs.repo_install_command }}
+        popd
       shell: bash
     - name: Run Unit Tests
       env:

--- a/action.yml
+++ b/action.yml
@@ -17,14 +17,9 @@ runs:
       with:
         repository: Qiskit/qiskit-neko
         path: qiskit-neko
-    - name: Access cloned repository content
-      run: |
-        cd qiskit-neko
-      shell: bash
     - name: Download Released Dependencies
       run: |
-        pip install .
-        cd ..
+        pip install qiskit-neko
       shell: bash
     - name: Checkout base repository
       uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
         path: qiskit-neko
     - name: Download Released Dependencies
       run: |
-        pip install qiskit-neko
+        pip install ./qiskit-neko
       shell: bash
     - name: Checkout base repository
       uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -20,15 +20,18 @@ runs:
     - name: Access cloned repository content
       run: |
         cd qiskit-neko
+      shell: bash
     - name: Download Released Dependencies
       run: |
         pip install .
         cd ..
+      shell: bash
     - name: Checkout base repository
       uses: actions/checkout@v3
     - name: Install repo under test
       run: |
         ${{ inputs.repo_install_command }}
+      shell: bash
     - name: Run Unit Tests
       env:
         PYTHONWARNINGS: default


### PR DESCRIPTION
The custom github action was missing a required parameter "shell" to
specify the shell to run commands in from several steps in the action.
This causes failures when trying to use the action as the action isn't
valid. This commit fixes this issue and updates the action to specify
all the commands are run in bash.