### PR TITLE
Split out qiskit requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-qiskit
+qiskit-terra
+qiskit-aer
 qiskit-nature[pyscf]
 qiskit-experiments
 qiskit-machine-learning


### PR DESCRIPTION
We previously had listed qiskit in the requirements list for qiskit
neko, this was because neko relies on both terra and aer so it was
easier to say the combined qiskit deliverable was the dependency.
However, this is leading to packaging warnings from pip in CI jobs
when we install a project under test from source. To side step these
warning this commit changes the requirement to explicitly list terra and
aer so that installing one from source (or a version different than the
listed version in the metapackage) will work without any potential
issues.