### PR TITLE
Fix deprecated import path

### DIFF
--- a/qiskit_neko/aer_plugin.py
+++ b/qiskit_neko/aer_plugin.py
@@ -12,8 +12,7 @@
 
 """Qiskit Aer default backend plugin."""
 
-from qiskit.providers import aer
-from qiskit.test.mock import fake_provider
+from qiskit.providers import aer, fake_provider
 
 from qiskit_neko import backend_plugin
 


### PR DESCRIPTION
Fixes the lint failure blocking #11.  `qiskit.providers.fake_provider` has been available since Terra 0.20.

I don't know what the minimum version of support for Terra we require is, so this might not be entirely appropriate - it might need import guards for more versions?