### PR TITLE
Add tests for primtives usage with algorithms and aer

### DIFF
--- a/qiskit_neko/tests/primitives/__init__.py
+++ b/qiskit_neko/tests/primitives/__init__.py
@@ -1,0 +1,11 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.

--- a/qiskit_neko/tests/primitives/test_vqe.py
+++ b/qiskit_neko/tests/primitives/test_vqe.py
@@ -1,0 +1,85 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test primitives with vqe."""
+
+from qiskit_aer.primitives import Sampler, Estimator
+from qiskit.algorithms.minimum_eigensolvers import SamplingVQE, VQE
+from qiskit.primitives import BackendSampler, BackendEstimator
+from qiskit.algorithms.optimizers import SPSA
+from qiskit.circuit.library import TwoLocal
+from qiskit.opflow import PauliSumOp
+from qiskit.quantum_info import SparsePauliOp
+
+from qiskit_neko import decorators
+from qiskit_neko.tests import base
+
+
+class TestVQEPrimitives(base.BaseTestCase):
+    """Test the use of the execute() method in qiskit-terra."""
+
+    def setUp(self):
+        super().setUp()
+        if hasattr(self.backend.options, "seed_simulator"):
+            self.backend.set_options(seed_simulator=42)
+
+    @decorators.component_attr("terra", "backend")
+    def test_sampling_vqe(self):
+        """Test the execution of SamplingVQE with BackendEstimator."""
+        sampler = BackendSampler(self.backend)
+        operator = PauliSumOp(SparsePauliOp(["ZZ", "IZ", "II"], coeffs=[1, -0.5, 0.12]))
+        ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+        optimizer = SPSA()
+        sampling_vqe = SamplingVQE(sampler, ansatz, optimizer)
+        result = sampling_vqe.compute_minimum_eigenvalue(operator)
+        eigenvalue = result.eigenvalue
+        expected = -1.38
+        self.assertAlmostEqual(expected, eigenvalue, delta=0.3)
+
+    @decorators.component_attr("terra", "aer")
+    def test_aer_sampling_vqe(self):
+        """Test the aer sampler with SamplingVQE."""
+        sampler = Sampler()
+        operator = PauliSumOp(SparsePauliOp(["ZZ", "IZ", "II"], coeffs=[1, -0.5, 0.12]))
+        ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+        optimizer = SPSA()
+        sampling_vqe = SamplingVQE(sampler, ansatz, optimizer)
+        result = sampling_vqe.compute_minimum_eigenvalue(operator)
+        eigenvalue = result.eigenvalue
+        expected = -1.38
+        self.assertAlmostEqual(expected, eigenvalue, delta=0.3)
+
+    @decorators.component_attr("terra", "backend")
+    def test_vqe(self):
+        """Test the execution of VQE with BackendEstimator."""
+        estimator = BackendEstimator(self.backend)
+        operator = PauliSumOp(SparsePauliOp(["ZZ", "IZ", "II"], coeffs=[1, -0.5, 0.12]))
+        ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+        optimizer = SPSA()
+        sampling_vqe = VQE(estimator, ansatz, optimizer)
+        result = sampling_vqe.compute_minimum_eigenvalue(operator)
+        eigenvalue = result.eigenvalue
+        expected = -1.38
+        self.assertAlmostEqual(expected, eigenvalue, delta=0.3)
+
+    @decorators.component_attr("terra", "aer")
+    def test_aer_vqe(self):
+        """Test the execution of VQE with Aer Estimator."""
+        estimator = Estimator()
+        operator = PauliSumOp(SparsePauliOp(["ZZ", "IZ", "II"], coeffs=[1, -0.5, 0.12]))
+        ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+        optimizer = SPSA()
+        sampling_vqe = VQE(estimator, ansatz, optimizer)
+        result = sampling_vqe.compute_minimum_eigenvalue(operator)
+        eigenvalue = result.eigenvalue
+        expected = -1.38
+        self.assertAlmostEqual(expected, eigenvalue, delta=0.3)

--- a/qiskit_neko/tests/primitives/test_vqe.py
+++ b/qiskit_neko/tests/primitives/test_vqe.py
@@ -34,7 +34,7 @@ class TestVQEPrimitives(base.BaseTestCase):
 
     @decorators.component_attr("terra", "backend")
     def test_sampling_vqe(self):
-        """Test the execution of SamplingVQE with BackendEstimator."""
+        """Test the execution of SamplingVQE with BackendSampler."""
         sampler = BackendSampler(self.backend)
         operator = PauliSumOp(SparsePauliOp(["ZZ", "IZ", "II"], coeffs=[1, -0.5, 0.12]))
         ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")


### PR DESCRIPTION
This commit adds some new tests that exercise the primtives API with algorithms is used. In Qiskit Terra 0.22.0 breaking API changes merged to the primitives API, while it is too late to roll them back we can prevent such user impacting breaking changes in the future by ensuring we have integration test coverage in qiskit-neko. Ths commit adds tests that use the BackendSampler and BackendEstimator primitives with SamplingVQE and VQE to test the backend interface, and then also to ensure we're validating the cross-project compatibility with the abstract primitive interface tests that use the specific Aer implementation of the primitives API is added. This will ensure that no change to qiskit-terra can merge which will break an external implementation of the primitives API in the future.

A follow on to this is to add support for configurable primitives similar to what we already have with backends. This will enable adding test jobs that use a provider's native primitive implenetations for primitive tests.