### PR TITLE
Fix lint issues with qiskit-aer >=0.11.0

### DIFF
--- a/qiskit_neko/aer_plugin.py
+++ b/qiskit_neko/aer_plugin.py
@@ -12,7 +12,8 @@
 
 """Qiskit Aer default backend plugin."""
 
-from qiskit.providers import aer, fake_provider
+import qiskit_aer as aer
+from qiskit.providers import fake_provider
 
 from qiskit_neko import backend_plugin
 


### PR DESCRIPTION
In the qiskit-aer 0.11.0 release the Python namespace of the project moved from qiskit.providers.aer to qiskit_aer. For backwards compatibility the old import path, qiskit.providers.aer, continues to work and will redirect to the new name. However, pylint's static analysis is not able to follow the metaimporter used to do this because it happens dynamically at import time. To correct this issue, this commit updates the import statement for aer to fix the lint job moving forward and also migrate the neko repo to the up-to-date usage.