### PR TITLE
Set seed for primitive based machine learning tests

### DIFF
--- a/qiskit_neko/tests/machine_learning/test_neural_network_classifier_primitives.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_network_classifier_primitives.py
@@ -30,7 +30,7 @@ class TestNeuralNetworkClassifierOnPrimitives(base.BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler())
+        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler(run_options={"seed": 42}))
 
     @decorators.component_attr("terra", "aer", "machine_learning")
     @data("reference", "aer")

--- a/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
@@ -37,8 +37,10 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         self.circuit = QuantumCircuit(1)
         self.circuit.ry(self.input_params[0], 0)
         self.circuit.rx(self.weight_params[0], 0)
-        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler())
-        self.estimators = dict(reference=ReferenceEstimator(), aer=AerEstimator())
+        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler(run_options={"seed": 42}))
+        self.estimators = dict(
+            reference=ReferenceEstimator(), aer=AerEstimator(run_options={"seed": 42})
+        )
 
     @decorators.component_attr("terra", "aer", "machine_learning")
     @data(["reference", 4], ["aer", 1])


### PR DESCRIPTION
In the recently added primitive based machine learning tests we forgot to set a seed on the Aer primtives. This has been causing a non-zero failure rate in CI as the the rng values cause poorer quality results than expected by the test tolerance. This commit sets a fixed seed via run option in the aer primitive initialization to ensure we're running with a stable rng output and the tests will pass consistently.