### PR TITLE
Update setuptools as part of action definition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,11 @@ runs:
       with:
         repository: Qiskit/qiskit-neko
         path: qiskit-neko
-    - name: Download Released Dependencies
+    - name: Update setuptools and pip
+      run: |
+        pip install -U setuptools pip
+      shell: bash
+    - name: Install neko and its dependencies
       run: |
         pip install ./qiskit-neko
       shell: bash


### PR DESCRIPTION
In CI for downstream projects the neko action has been failing on a setuptools error. This only started recently, likely from a change in version published in the base image. This commit attempts to fix this by updating the setuptools and pip version to the latest release as part of the action definition.