### PR TITLE
set initial point for VQC

### DIFF
--- a/qiskit_neko/tests/machine_learning/test_neural_network_classifier.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_network_classifier.py
@@ -56,6 +56,7 @@ class TestNeuralNetworkClassifier(base.BaseTestCase):
             loss="cross_entropy",
             optimizer=COBYLA(),
             quantum_instance=quantum_instance,
+            initial_point=np.zeros((2, 2)),
         )
 
         vqc.fit(x, y_one_hot)

--- a/qiskit_neko/tests/machine_learning/test_neural_network_classifier_primitives.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_network_classifier_primitives.py
@@ -45,7 +45,12 @@ class TestNeuralNetworkClassifierOnPrimitives(base.BaseTestCase):
         y01 = 1 * (np.sum(x, axis=1) >= 0)
 
         sampler = self.samplers[implementation]
-        vqc = VQC(num_qubits=2, optimizer=COBYLA(maxiter=100), sampler=sampler)
+        vqc = VQC(
+            num_qubits=2,
+            optimizer=COBYLA(maxiter=100),
+            sampler=sampler,
+            initial_point=np.zeros((2, 4)),
+        )
 
         vqc.fit(x, y01)
         score = vqc.score(x, y01)


### PR DESCRIPTION
Fixes https://github.com/Qiskit/qiskit-neko/issues/25

@woodsp-ibm mentioned that the VQC initial_point is random unless explicitly set. So... setting it :)
