### PR TITLE
Bad link formatting in config.html doc

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -4,7 +4,7 @@ Qiskit-Neko Configuration Files
 To support running against different backends and also tune the execute of
 tests qiskit-neko supports configuration files to tweak the configuration
 and make reproducible testing simpler. The format for qiskit-neko's
-configuration is a [yaml](https://yaml.org/) file, a fully populated example
+configuration is a `yaml <https://yaml.org/>`_ file, a fully populated example
 is below:
 
 .. code-block:: yaml
@@ -72,8 +72,8 @@ none of the subsequent locations will be checked:
 #. ``/etc/neko_config.yml``
 
 Since the actual execution of tests is handled by the external Python standard
-library [unittest](https://docs.python.org/3/library/unittest.html) framework
-the only mechanism to excplictly specify a configuration file path is with an
+library `unittest <https://docs.python.org/3/library/unittest.html>`_ framework
+the only mechanism to explicitly specify a configuration file path is with an
 environment variable. You can set the environment variable ``NekoConfigPath`` to
 the absolute path to the configuration file. If this is specified it will be
 used regardless of a file being present in any of the default file locations.


### PR DESCRIPTION
In https://qiskit.org/documentation/neko/config.html, the link formatting seems md instead of rst.
![screencapture-file-private-tmp-config-html-2023-05-25-10_50_08](https://github.com/Qiskit/qiskit-neko/assets/766693/12d8b279-f23a-4d7a-904d-ff5a78ae5f9a)

And there is a small typo.
