### PR TITLE
Change dependency on `qiskit-terra` to `qiskit`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra
+qiskit
 qiskit-algorithms
 qiskit-aer
 qiskit-nature[pyscf]


### PR DESCRIPTION
This is completely valid for Qiskit versions >=0.44, and at the time of writing the supported release is 0.45.0.  This change is necessary moving forwards, since Qiskit 1.0 will not include a `qiskit-terra` package at all.