### PR TITLE
Remove links to qiskit.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 First read the overall project contributing guidelines. These are all
 included in the qiskit documentation:
 
-https://qiskit.org/documentation/contributing_to_qiskit.html
+https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md
 
 ## Contributing to qiskit-neko
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-neko.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
 
   - You can see the full rendered docs at:
-    <https://qiskit.org/documentation/neko>
+    <https://qiskit.org/ecosystem/neko>
 
 
 This repository contains integration tests for Qiskit. These tests are used
@@ -11,7 +11,7 @@ for primarily for two purposes as backwards compatibility testing for Qiskit
 to validate that changes proposed to any Qiskit project do not break
 functionality from previous release and to validate that functionality works
 as expected with different providers. A provider in Qiskit is a package that
-provides [backend](https://qiskit.org/documentation/stubs/qiskit.providers.BackendV2.html)
+provides [backend](https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.BackendV2)
 objects that provide an interface to Quantum hardware or a simulator.
 
 ## Installing qiskit-neko

--- a/docs/_templates/theme_variables.jinja
+++ b/docs/_templates/theme_variables.jinja
@@ -1,8 +1,0 @@
-{%- set external_urls = {
-  'github': 'https://github.com/Qiskit/retworkx',
-  'docs': 'https://retworkx.readthedocs.io/en/stable/',
-  'slack': 'https://qiskit.slack.com',
-  'home': 'https://qiskit.org/',
-  'resources': 'https://qiskit.org/learn',
-}
--%}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,6 @@ html_title = f"{project} {release}"
 
 htmlhelp_basename = 'qiskit-neko'
 
-# Intersphinx configuration
 intersphinx_mapping = {
-    'qiskit': ('https://qiskit.org/documentation/', None),
+    'qiskit': ('https://docs.quantum.ibm.com/api/qiskit/', None),
 }

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     python_requires=">=3.8",
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-neko/issues",
-        "Documentation": "https://qiskit.org/documentation/",
+        "Documentation": "https://qiskit.org/ecosystem/neko",
         "Source Code": "https://github.com/Qiskit/qiskit-neko",
     },
     zip_safe=False,


### PR DESCRIPTION
We can't yet replace https://qiskit.org/ecosystem/neko with its new GitHub pages URL until that is published.