### PR TITLE
Update tests for Qiskit 1.0

### DIFF
--- a/qiskit_neko/tests/circuits/test_execute.py
+++ b/qiskit_neko/tests/circuits/test_execute.py
@@ -15,7 +15,7 @@
 import math
 
 from qiskit.circuit import QuantumCircuit
-from qiskit import execute
+from qiskit import transpile
 
 from qiskit_neko import decorators
 from qiskit_neko.tests import base
@@ -40,7 +40,7 @@ class TestExecute(base.BaseTestCase):
         circuit.h(0)
         circuit.cx(0, 1)
         circuit.measure_all()
-        job = execute(circuit, self.backend, shots=100)
+        job = self.backend.run(transpile(circuit, self.backend), shots=100)
         result = job.result()
         counts = result.get_counts()
         self.assertDictAlmostEqual(counts, {"00": 50, "11": 50}, delta=10)
@@ -53,7 +53,7 @@ class TestExecute(base.BaseTestCase):
         circuit.cx(0, 1)
         circuit.measure_all()
         expected_count = self.backend.options.shots / 2
-        job = execute(circuit, self.backend)
+        job = self.backends.run(transpile(circuit, self.backend))
         result = job.result()
         counts = result.get_counts()
         delta = 10 ** (math.log10(self.backend.options.shots) - 1)
@@ -69,7 +69,7 @@ class TestExecute(base.BaseTestCase):
         circuit.cx(0, 1)
         circuit.measure_all()
         self.backend.set_options(shots=100)
-        job = execute(circuit, self.backend)
+        job = self.backend.run(transpile(circuit, self.backend))
         result = job.result()
         counts = result.get_counts()
         self.assertDictAlmostEqual(counts, {"00": 50, "11": 50}, delta=10)


### PR DESCRIPTION
This commit updates the execute tests to remove the use of execute() which was removed in Qiskit 1.0 after being deprecated in 0.46. How this managed to merge, I'm not entirely clear on because it should have failed CI on the removal PR, so there is likely a configuration issue in the neko custom action as well that will need to be fixed.