### PR TITLE
Bump actions/checkout to latest version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Clone Qiskit/qiskit-neko PUBLIC repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Qiskit/qiskit-neko
         path: qiskit-neko
@@ -26,7 +26,7 @@ runs:
         pip install ./qiskit-neko
       shell: bash
     - name: Checkout base repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: repo_under_test
     - name: Install repo under test


### PR DESCRIPTION
This commit bumps the actions/checkout version used in the custom neko action.