### PR TITLE
Build `ibm-platform-services` with known-good setuptools

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,23 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
+
+    # This can be removed when `ibm-platform-services` can build/install with the most recent of
+    # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+    - name: Prebuild old-setuptools dependencies
+      shell: bash
+      run: |
+        set -e
+        python -m venv .build-deps
+        if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+          .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+          .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+        else
+          .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+          .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+        fi
+        rm -rf .build-deps
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,23 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
@@ -61,6 +78,23 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-neko-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Install Deps
         run: python -m pip install -U tox
       - name: Run neko
@@ -87,6 +121,23 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-lint-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Install Deps
         run: python -m pip install -U tox
       - name: Run lint
@@ -112,6 +163,23 @@ jobs:
             ${{ runner.os }}-pip-docs-
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Install Deps
         run: |
           python -m pip install -U tox

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,23 @@ runs:
       run: |
         pip install -U setuptools pip
       shell: bash
+
+    # This can be removed when `ibm-platform-services` can build/install with the most recent of
+    # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+    - name: Prebuild old-setuptools dependencies
+      shell: bash
+      run: |
+        set -e
+        python -m venv .build-deps
+        if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+          .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+          .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+        else
+          .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+          .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+        fi
+        rm -rf .build-deps
+
     - name: Install neko and its dependencies
       run: |
         pip install ./qiskit-neko


### PR DESCRIPTION
`ibm-platform-services<=0.55.1` only supply an `sdist` on PyPI, and the `setup.py` of that sdist imports the deprecated `setuptools.commands.test`, which is removed in `setuptools==72.0.0`.  This makes the package unbuildable with the latest `setuptools`, and it's hard to thread through a constraint on build dependencies right into the depths of recursive pip/tox/whatever commands.

This commit forcibly builds the bad dependency with an older version of `setuptools` and adds the wheel to the pip cache, so subsequent installation commands will be able to install from a pre-built wheel regardless of the `setuptools` version.
