### PR TITLE
Use FakeProviderForBackendV2()

### DIFF
--- a/qiskit_neko/aer_plugin.py
+++ b/qiskit_neko/aer_plugin.py
@@ -52,5 +52,5 @@ class AerBackendPlugin(backend_plugin.BackendPlugin):
             method = backend_selection.split("=")[1]
             return aer.AerSimulator(method=method)
         if backend_selection in self.mock_provider_backend_names:
-            return self.mock_provider.get_backend(backend_selection)
+            return self.mock_provider.backend(backend_selection)
         raise ValueError(f"Invalid selection string {backend_selection}.")

--- a/qiskit_neko/aer_plugin.py
+++ b/qiskit_neko/aer_plugin.py
@@ -13,7 +13,7 @@
 """Qiskit Aer default backend plugin."""
 
 import qiskit_aer as aer
-from qiskit_ibm_runtime import fake_provider
+from qiskit_ibm_runtime.fake_provider import FakeProviderForBackendV2
 
 from qiskit_neko import backend_plugin
 
@@ -23,7 +23,7 @@ class AerBackendPlugin(backend_plugin.BackendPlugin):
 
     def __init__(self):
         super().__init__()
-        self.mock_provider = fake_provider.FakeProvider()
+        self.mock_provider = FakeProviderForBackendV2()
         self.mock_provider_backend_names = set()
         for backend in self.mock_provider.backends():
             if backend.version == 1:


### PR DESCRIPTION
`FakeProvider()` was removed in the latest release of `qiskit-ibm-runtime` 