### PR TITLE
Remove Backend primtive v1 dependent tests

### DIFF
--- a/qiskit_neko/tests/machine_learning/test_neural_network_classifier.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_network_classifier.py
@@ -14,7 +14,6 @@
 import numpy as np
 from ddt import ddt, data
 
-from qiskit.primitives import Sampler as ReferenceSampler
 from qiskit_aer.primitives import Sampler as AerSampler
 
 from qiskit_algorithms.optimizers import COBYLA
@@ -33,10 +32,10 @@ class TestNeuralNetworkClassifierOnPrimitives(base.BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler(run_options={"seed": 42}))
+        self.samplers = dict(aer=AerSampler(run_options={"seed": 42}))
 
     @decorators.component_attr("terra", "aer", "machine_learning")
-    @data("reference", "aer")
+    @data("aer")
     def test_neural_network_classifier(self, implementation):
         """Test the execution of quantum neural networks using VQC."""
         rng = np.random.default_rng(seed=42)

--- a/qiskit_neko/tests/machine_learning/test_neural_network_classifier.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_network_classifier.py
@@ -14,6 +14,7 @@
 import numpy as np
 from ddt import ddt, data
 
+from qiskit.primitives import StatevectorSampler as ReferenceSampler
 from qiskit_aer.primitives import Sampler as AerSampler
 
 from qiskit_algorithms.optimizers import COBYLA
@@ -32,10 +33,10 @@ class TestNeuralNetworkClassifierOnPrimitives(base.BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        self.samplers = dict(aer=AerSampler(run_options={"seed": 42}))
+        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler(run_options={"seed": 42}))
 
     @decorators.component_attr("terra", "aer", "machine_learning")
-    @data("aer")
+    @data("reference", "aer")
     def test_neural_network_classifier(self, implementation):
         """Test the execution of quantum neural networks using VQC."""
         rng = np.random.default_rng(seed=42)

--- a/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
@@ -16,7 +16,6 @@ import numpy as np
 from ddt import ddt, data, unpack
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
-from qiskit.primitives import Sampler as ReferenceSampler, Estimator as ReferenceEstimator
 from qiskit.quantum_info import SparsePauliOp
 
 from qiskit_aer.primitives import Sampler as AerSampler, Estimator as AerEstimator
@@ -38,13 +37,13 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         self.circuit = QuantumCircuit(1)
         self.circuit.ry(self.input_params[0], 0)
         self.circuit.rx(self.weight_params[0], 0)
-        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler(run_options={"seed": 42}))
+        self.samplers = dict(aer=AerSampler(run_options={"seed": 42}))
         self.estimators = dict(
-            reference=ReferenceEstimator(), aer=AerEstimator(run_options={"seed": 42})
+            aer=AerEstimator(run_options={"seed": 42})
         )
 
     @decorators.component_attr("terra", "aer", "machine_learning")
-    @data(["reference", 4], ["aer", 1])
+    @data(["aer", 1])
     @unpack
     def test_sampler_qnn(self, implementation, decimal):
         """Test the execution of quantum neural networks using SamplerQNN."""
@@ -66,7 +65,7 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         np.testing.assert_array_almost_equal(weight_grad, [[[-0.2273], [0.2273]]], decimal)
 
     @decorators.component_attr("terra", "aer", "machine_learning")
-    @data(["reference", 4], ["aer", 1])
+    @data(["aer", 1])
     @unpack
     def test_estimator_qnn(self, implementation, decimal):
         """Test the execution of quantum neural networks using EstimatorQNN."""

--- a/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
@@ -41,7 +41,9 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         self.circuit = QuantumCircuit(1)
         self.circuit.ry(self.input_params[0], 0)
         self.circuit.rx(self.weight_params[0], 0)
-        self.samplers = dict(reference=ReferenceSampler(seed=42), aer=AerSampler(run_options={"seed": 42}))
+        self.samplers = dict(
+            reference=ReferenceSampler(seed=42), aer=AerSampler(run_options={"seed": 42})
+        )
         self.estimators = dict(
             reference=ReferenceEstimator(seed=42), aer=AerEstimator(run_options={"seed": 42})
         )

--- a/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
@@ -18,6 +18,10 @@ from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.quantum_info import SparsePauliOp
 
+from qiskit.primitives import (
+    StatevectorSampler as ReferenceSampler,
+    StatevectorEstimator as ReferenceEstimator,
+)
 from qiskit_aer.primitives import Sampler as AerSampler, Estimator as AerEstimator
 from qiskit_machine_learning.neural_networks import SamplerQNN, EstimatorQNN
 
@@ -37,13 +41,13 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         self.circuit = QuantumCircuit(1)
         self.circuit.ry(self.input_params[0], 0)
         self.circuit.rx(self.weight_params[0], 0)
-        self.samplers = dict(aer=AerSampler(run_options={"seed": 42}))
+        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler(run_options={"seed": 42}))
         self.estimators = dict(
-            aer=AerEstimator(run_options={"seed": 42})
+            reference=ReferenceEstimator(), aer=AerEstimator(run_options={"seed": 42})
         )
 
     @decorators.component_attr("terra", "aer", "machine_learning")
-    @data(["aer", 1])
+    @data(["reference", 4], ["aer", 1])
     @unpack
     def test_sampler_qnn(self, implementation, decimal):
         """Test the execution of quantum neural networks using SamplerQNN."""
@@ -65,7 +69,7 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         np.testing.assert_array_almost_equal(weight_grad, [[[-0.2273], [0.2273]]], decimal)
 
     @decorators.component_attr("terra", "aer", "machine_learning")
-    @data(["aer", 1])
+    @data(["reference", 4], ["aer", 1])
     @unpack
     def test_estimator_qnn(self, implementation, decimal):
         """Test the execution of quantum neural networks using EstimatorQNN."""

--- a/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
@@ -41,13 +41,13 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         self.circuit = QuantumCircuit(1)
         self.circuit.ry(self.input_params[0], 0)
         self.circuit.rx(self.weight_params[0], 0)
-        self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler(run_options={"seed": 42}))
+        self.samplers = dict(reference=ReferenceSampler(seed=42), aer=AerSampler(run_options={"seed": 42}))
         self.estimators = dict(
-            reference=ReferenceEstimator(), aer=AerEstimator(run_options={"seed": 42})
+            reference=ReferenceEstimator(seed=42), aer=AerEstimator(run_options={"seed": 42})
         )
 
     @decorators.component_attr("terra", "aer", "machine_learning")
-    @data(["reference", 4], ["aer", 1])
+    @data(["reference", 2], ["aer", 1])
     @unpack
     def test_sampler_qnn(self, implementation, decimal):
         """Test the execution of quantum neural networks using SamplerQNN."""
@@ -69,7 +69,7 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         np.testing.assert_array_almost_equal(weight_grad, [[[-0.2273], [0.2273]]], decimal)
 
     @decorators.component_attr("terra", "aer", "machine_learning")
-    @data(["reference", 4], ["aer", 1])
+    @data(["reference", 2], ["aer", 1])
     @unpack
     def test_estimator_qnn(self, implementation, decimal):
         """Test the execution of quantum neural networks using EstimatorQNN."""

--- a/qiskit_neko/tests/primitives/test_vqe.py
+++ b/qiskit_neko/tests/primitives/test_vqe.py
@@ -13,7 +13,6 @@
 """Test primitives with vqe."""
 
 from qiskit.circuit.library import TwoLocal
-from qiskit.primitives import BackendEstimator, BackendSampler
 from qiskit.quantum_info import SparsePauliOp
 
 from qiskit_algorithms import VQE, SamplingVQE
@@ -35,19 +34,6 @@ class TestVQEPrimitives(base.BaseTestCase):
         if hasattr(self.backend.options, "seed_simulator"):
             self.backend.set_options(seed_simulator=42)
 
-    @decorators.component_attr("terra", "backend", "algorithms")
-    def test_sampling_vqe(self):
-        """Test the execution of SamplingVQE with BackendSampler."""
-        sampler = BackendSampler(self.backend)
-        operator = SparsePauliOp(["ZZ", "IZ", "II"], coeffs=[1, -0.5, 0.12])
-        ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
-        optimizer = SPSA()
-        sampling_vqe = SamplingVQE(sampler, ansatz, optimizer)
-        result = sampling_vqe.compute_minimum_eigenvalue(operator)
-        eigenvalue = result.eigenvalue
-        expected = -1.38
-        self.assertAlmostEqual(expected, eigenvalue, delta=0.3)
-
     @decorators.component_attr("terra", "aer", "algorithms")
     def test_aer_sampling_vqe(self):
         """Test the aer sampler with SamplingVQE."""
@@ -56,19 +42,6 @@ class TestVQEPrimitives(base.BaseTestCase):
         ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
         optimizer = SPSA()
         sampling_vqe = SamplingVQE(sampler, ansatz, optimizer)
-        result = sampling_vqe.compute_minimum_eigenvalue(operator)
-        eigenvalue = result.eigenvalue
-        expected = -1.38
-        self.assertAlmostEqual(expected, eigenvalue, delta=0.3)
-
-    @decorators.component_attr("terra", "backend", "algorithms")
-    def test_vqe(self):
-        """Test the execution of VQE with BackendEstimator."""
-        estimator = BackendEstimator(self.backend)
-        operator = SparsePauliOp(["ZZ", "IZ", "II"], coeffs=[1, -0.5, 0.12])
-        ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
-        optimizer = SPSA()
-        sampling_vqe = VQE(estimator, ansatz, optimizer)
         result = sampling_vqe.compute_minimum_eigenvalue(operator)
         eigenvalue = result.eigenvalue
         expected = -1.38


### PR DESCRIPTION
Right now there are tests that rely on the `BackendSampler`, `Sampler`, `Estimator` and `BackendEstimator` classes. These tests are testing the full path execution workflow with primitives for qiskit-algorithms and application modules with v1 implementations as input to these modules. However, these v1 primitive implementations are deprecated and will be removed in qiskit 2.0. This makes these test infeasible moving forward because qiskit-algorithms only supports the primitives v1 interface, so while there is a v2 interface available for the backend primitives in qiskit these can't be used with algorithms anymore. So this commit deletes the tests in questions to unblock the qiskit removal PR.