### PR TITLE
Update ci configuration to use supported python version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.12'
 
     # This can be removed when `ibm-platform-services` can build/install with the most recent of
     # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,23 +15,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-
-    # This can be removed when `ibm-platform-services` can build/install with the most recent of
-    # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
-    - name: Prebuild old-setuptools dependencies
-      shell: bash
-      run: |
-        set -e
-        python -m venv .build-deps
-        if [[ ${{ runner.os }} =~ [wW]indows ]]; then
-          .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
-          .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
-        else
-          .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
-          .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
-        fi
-        rm -rf .build-deps
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,22 +39,6 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
 
-      # This can be removed when `ibm-platform-services` can build/install with the most recent of
-      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
-      - name: Prebuild old-setuptools dependencies
-        shell: bash
-        run: |
-          set -e
-          python -m venv .build-deps
-          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
-            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
-            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
-          else
-            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
-            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
-          fi
-          rm -rf .build-deps
-
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
@@ -78,22 +62,6 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-neko-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
-
-      # This can be removed when `ibm-platform-services` can build/install with the most recent of
-      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
-      - name: Prebuild old-setuptools dependencies
-        shell: bash
-        run: |
-          set -e
-          python -m venv .build-deps
-          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
-            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
-            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
-          else
-            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
-            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
-          fi
-          rm -rf .build-deps
 
       - name: Install Deps
         run: python -m pip install -U tox
@@ -122,22 +90,6 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
 
-      # This can be removed when `ibm-platform-services` can build/install with the most recent of
-      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
-      - name: Prebuild old-setuptools dependencies
-        shell: bash
-        run: |
-          set -e
-          python -m venv .build-deps
-          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
-            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
-            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
-          else
-            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
-            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
-          fi
-          rm -rf .build-deps
-
       - name: Install Deps
         run: python -m pip install -U tox
       - name: Run lint
@@ -163,22 +115,6 @@ jobs:
             ${{ runner.os }}-pip-docs-
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
-
-      # This can be removed when `ibm-platform-services` can build/install with the most recent of
-      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
-      - name: Prebuild old-setuptools dependencies
-        shell: bash
-        run: |
-          set -e
-          python -m venv .build-deps
-          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
-            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
-            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
-          else
-            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
-            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
-          fi
-          rm -rf .build-deps
 
       - name: Install Deps
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.11]
+        python-version: [3.9, 3.13]
         os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
     steps:
       - name: Print Concurrency Group
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Pip cache
         uses: actions/cache@v4
         with:
@@ -108,10 +108,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Pip cache
         uses: actions/cache@v4
         with:
@@ -150,10 +150,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Pip cache
         uses: actions/cache@v4
         with:

--- a/action.yml
+++ b/action.yml
@@ -22,22 +22,6 @@ runs:
         pip install -U setuptools pip
       shell: bash
 
-    # This can be removed when `ibm-platform-services` can build/install with the most recent of
-    # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
-    - name: Prebuild old-setuptools dependencies
-      shell: bash
-      run: |
-        set -e
-        python -m venv .build-deps
-        if [[ ${{ runner.os }} =~ [wW]indows ]]; then
-          .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
-          .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
-        else
-          .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
-          .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
-        fi
-        rm -rf .build-deps
-
     - name: Install neko and its dependencies
       run: |
         pip install ./qiskit-neko

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,8 +38,6 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.extlinks',
               'sphinx.ext.todo',
               'sphinx.ext.viewcode',
-              'jupyter_sphinx',
-              'reno.sphinxext',
               'sphinx.ext.intersphinx',
               'qiskit_sphinx_theme',
              ]

--- a/qiskit_neko/__init__.py
+++ b/qiskit_neko/__init__.py
@@ -13,4 +13,4 @@
 """qiskit-neko integration test suite."""
 
 
-from qiskit_neko.version import __version__
+from qiskit_neko.version import __version__ as __version__

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,3 +1,0 @@
----
-encoding: utf8
-default_branch: main

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black~=22.0
 astroid==2.9.2
 pylint==2.12.2
 Sphinx>=3.0.0
-qiskit-sphinx-theme~=1.16.0
+qiskit-sphinx-theme
 sphinx-autodoc-typehints
 jupyter-sphinx
 pygments>=2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 black~=22.0
-astroid==2.9.2
-pylint==2.12.2
+ruff==0.9.7
 Sphinx>=3.0.0
 qiskit-sphinx-theme
 sphinx-autodoc-typehints

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,4 @@ pylint==2.12.2
 Sphinx>=3.0.0
 qiskit-sphinx-theme
 sphinx-autodoc-typehints
-jupyter-sphinx
 pygments>=2.4
-reno>=3.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
 envdir = .tox/lint
 commands =
   black --check {posargs} qiskit_neko tests
-  pylint -rn --rcfile={toxinidir}/.pylintrc qiskit_neko/ tests/
+  ruff check qiskit_neko/ tests/
   python tools/verify_headers.py
 
 [testenv:black]


### PR DESCRIPTION
The repo hasn't been updated in some time as the tests were working as-is. But in the meantime the CI configuration has bitrotted slightly. The tests are all built around using python 3.8 which is now unsupported both by qiskit and cPython. This commit updates the configuration to fix this and unblock CI.