### PR TITLE
Skip qiskit-machine-learning tests until the downstream dependencies are updated to 2.0

### DIFF
--- a/qiskit_neko/aer_plugin.py
+++ b/qiskit_neko/aer_plugin.py
@@ -12,9 +12,6 @@
 
 """Qiskit Aer default backend plugin."""
 
-import qiskit_aer as aer
-from qiskit_ibm_runtime.fake_provider import FakeProviderForBackendV2
-
 from qiskit_neko import backend_plugin
 
 
@@ -22,6 +19,8 @@ class AerBackendPlugin(backend_plugin.BackendPlugin):
     """A backend plugin for using qiskit-aer as the backend."""
 
     def __init__(self):
+        from qiskit_ibm_runtime.fake_provider import FakeProviderForBackendV2
+
         super().__init__()
         self.mock_provider = FakeProviderForBackendV2()
         self.mock_provider_backend_names = set()
@@ -46,6 +45,8 @@ class AerBackendPlugin(backend_plugin.BackendPlugin):
             the defailt settings.
         :raises ValueError: If an invalid backend selection string is passed in
         """
+        import qiskit_aer as aer
+
         if backend_selection is None:
             return aer.AerSimulator()
         if backend_selection.startswith("method="):

--- a/qiskit_neko/tests/machine_learning/test_neural_network_classifier.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_network_classifier.py
@@ -13,14 +13,10 @@
 """Tests for quantum neural networks classifier."""
 import numpy as np
 from ddt import ddt, data
+import unittest
 
+from qiskit import __version__ as qiskit_version
 from qiskit.primitives import StatevectorSampler as ReferenceSampler
-from qiskit_aer.primitives import Sampler as AerSampler
-
-from qiskit_machine_learning.optimizers import COBYLA
-from qiskit_machine_learning.utils import algorithm_globals
-
-from qiskit_machine_learning.algorithms.classifiers import VQC
 
 from qiskit_neko import decorators
 from qiskit_neko.tests import base
@@ -30,15 +26,31 @@ from qiskit_neko.tests import base
 class TestNeuralNetworkClassifierOnPrimitives(base.BaseTestCase):
     """Test adapted from the qiskit_machine_learning tutorials."""
 
+    @unittest.skipIf(
+        tuple(map(int, qiskit_version.split(".")[:2])) >= (2, 0),
+        "Skipping test until Qiskit Aer and Machine Learning are ready for Qiskit 2.0. "
+        "Tracked in: https://github.com/Qiskit/qiskit-neko/issues/54",
+    )
     def setUp(self):
-        super().setUp()
+        from qiskit_aer.primitives import Sampler as AerSampler
 
+        super().setUp()
         self.samplers = dict(reference=ReferenceSampler(), aer=AerSampler(run_options={"seed": 42}))
 
+    @unittest.skipIf(
+        tuple(map(int, qiskit_version.split(".")[:2])) >= (2, 0),
+        "Skipping test until Qiskit Aer and Machine Learning are ready for Qiskit 2.0. "
+        "Tracked in: https://github.com/Qiskit/qiskit-neko/issues/54",
+    )
     @decorators.component_attr("terra", "aer", "machine_learning")
     @data("reference", "aer")
     def test_neural_network_classifier(self, implementation):
         """Test the execution of quantum neural networks using VQC."""
+
+        from qiskit_machine_learning.optimizers import COBYLA
+        from qiskit_machine_learning.utils import algorithm_globals
+        from qiskit_machine_learning.algorithms.classifiers import VQC
+
         rng = np.random.default_rng(seed=42)
         algorithm_globals.random_seed = 42
 

--- a/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
+++ b/qiskit_neko/tests/machine_learning/test_neural_networks_primitives.py
@@ -14,16 +14,16 @@
 
 import numpy as np
 from ddt import ddt, data, unpack
+import unittest
+
+from qiskit import __version__ as qiskit_version
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.quantum_info import SparsePauliOp
-
 from qiskit.primitives import (
     StatevectorSampler as ReferenceSampler,
     StatevectorEstimator as ReferenceEstimator,
 )
-from qiskit_aer.primitives import Sampler as AerSampler, Estimator as AerEstimator
-from qiskit_machine_learning.neural_networks import SamplerQNN, EstimatorQNN
 
 from qiskit_neko import decorators
 from qiskit_neko.tests import base
@@ -33,8 +33,15 @@ from qiskit_neko.tests import base
 class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
     """Test adapted from the qiskit_machine_learning tutorials."""
 
+    @unittest.skipIf(
+        tuple(map(int, qiskit_version.split(".")[:2])) >= (2, 0),
+        "Skipping test until Qiskit Aer and Machine Learning are ready for Qiskit 2.0. "
+        "Tracked in: https://github.com/Qiskit/qiskit-neko/issues/54",
+    )
     def setUp(self):
         super().setUp()
+
+        from qiskit_aer.primitives import Sampler as AerSampler, Estimator as AerEstimator
 
         self.input_params = [Parameter("x")]
         self.weight_params = [Parameter("w")]
@@ -48,11 +55,18 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
             reference=ReferenceEstimator(seed=42), aer=AerEstimator(run_options={"seed": 42})
         )
 
+    @unittest.skipIf(
+        tuple(map(int, qiskit_version.split(".")[:2])) >= (2, 0),
+        "Skipping test until Qiskit Aer and Machine Learning are ready for Qiskit 2.0. "
+        "Tracked in: https://github.com/Qiskit/qiskit-neko/issues/54",
+    )
     @decorators.component_attr("terra", "aer", "machine_learning")
     @data(["reference", 2], ["aer", 1])
     @unpack
     def test_sampler_qnn(self, implementation, decimal):
         """Test the execution of quantum neural networks using SamplerQNN."""
+        from qiskit_machine_learning.neural_networks import SamplerQNN
+
         sampler = self.samplers[implementation]
 
         qnn = SamplerQNN(
@@ -70,11 +84,18 @@ class TestNeuralNetworksOnPrimitives(base.BaseTestCase):
         np.testing.assert_array_almost_equal(input_grad, [[[-0.2273], [0.2273]]], decimal)
         np.testing.assert_array_almost_equal(weight_grad, [[[-0.2273], [0.2273]]], decimal)
 
+    @unittest.skipIf(
+        tuple(map(int, qiskit_version.split(".")[:2])) >= (2, 0),
+        "Skipping test until Qiskit Aer and Machine Learning are ready for Qiskit 2.0. "
+        "Tracked in: https://github.com/Qiskit/qiskit-neko/issues/54",
+    )
     @decorators.component_attr("terra", "aer", "machine_learning")
     @data(["reference", 2], ["aer", 1])
     @unpack
     def test_estimator_qnn(self, implementation, decimal):
         """Test the execution of quantum neural networks using EstimatorQNN."""
+        from qiskit_machine_learning.neural_networks import EstimatorQNN
+
         estimator = self.estimators[implementation]
 
         qnn = EstimatorQNN(


### PR DESCRIPTION
The removal of BackendV1 and primitives V1 cause the tests in `qiskit_neko/tests/machine-learning` to fail. This is part of the tests that are blocking the https://github.com/Qiskit/qiskit/pull/13793 and https://github.com/Qiskit/qiskit/pull/13872 PR in Qiskit from being merged. 

There are corresponding PRs in Qiskit Aer, Runtime, and issue in Machine Learning to address this failure. Until they are merged, we need to skip these failing tests. 

Tracked in #54 