### PR TITLE
Update `packaging` with `setuptools` to avoid version inconsistencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel tox packaging
         sudo apt-get install graphviz pandoc
     - name: Build docs
       run: tox -edocs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}
 
       - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
+        run: python -m pip install -U tox setuptools virtualenv wheel packaging
       - name: Install and Run Tests
         run: tox -e py
   neko:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
         path: qiskit-neko
     - name: Update setuptools and pip
       run: |
-        pip install -U setuptools pip
+        pip install -U setuptools pip packaging
       shell: bash
 
     - name: Install neko and its dependencies


### PR DESCRIPTION
A limitation in the `setuptools` vendoring system causes `setuptools` to fail to import if `packaging<24.2` is installed (https://github.com/pypa/setuptools/issues/4894). This PR adds an explicit update of `packaging` every time `setuptools` is installed to work around this issue.

