### PR TITLE
Unskip test_ghz_circuit_quantum_info test

### DIFF
--- a/qiskit_neko/tests/experiments/test_tomography.py
+++ b/qiskit_neko/tests/experiments/test_tomography.py
@@ -11,29 +11,20 @@
 # that they have been altered from the originals.
 
 """Tests for quantum state tomography."""
-import unittest
-
 from qiskit import QuantumCircuit
 from qiskit.quantum_info import DensityMatrix, state_fidelity
 
 from qiskit_neko import decorators
 from qiskit_neko.tests import base
-import qiskit
+from qiskit_experiments.library import StateTomography
 
 
 class TestQuantumStateTomography(base.BaseTestCase):
     """Tests adapted from circuit basics tutorial."""
 
-    @unittest.skipIf(
-        tuple(map(int, qiskit.__version__.split(".")[:2])) >= (2, 0),
-        "Skipping test until Qiskit Experiments is ready for Qiskit 2.0. "
-        "Tracked in: https://github.com/Qiskit/qiskit-neko/issues/54",
-    )
     @decorators.component_attr("terra", "backend", "experiment")
     def test_ghz_circuit_quantum_info(self):
         """Test state tomography of ghz state circuit"""
-
-        from qiskit_experiments.library import StateTomography
 
         nq = 3
         qc_ghz = QuantumCircuit(nq)


### PR DESCRIPTION
This test was previously skipped because Qiskit Experiments was not compatible with Qiskit 2.0 and the test blocked Qiskit PRs. With the release of Qiskit Experiments 0.9.0, this skip can be removed.

Tracked in #54

